### PR TITLE
feat(updater-github) - Enable authenticated GitHub package downloads …

### DIFF
--- a/includes/Core/GithubConnector.php
+++ b/includes/Core/GithubConnector.php
@@ -153,54 +153,56 @@ class GithubConnector extends Connector
         return $ret;
     }
 
-    /**
-     * Download a ZIP archive of a specific branch of a GitHub repository
-     * and save it to disk. Return false on failure or rate limit reached.
-     *
-     * @param string $repository The name of the repository.
-     * @param string $branch The branch name.
-     * @return string|boolean Local path to the ZIP file, or false on failure.
-     */
-    public function downloadRepoZip(string $repository, string $branch = 'main'): string|bool
+    public function downloadRepoZip(string $repository, string $branch = 'main'): string
     {
-        $url = sprintf(
-            'https://api.github.com/repos/%1$s/%2$s/zipball/%3$s',
-            $this->owner,
-            $repository,
-            $branch
+        return $this->getRepoZipUrl($repository, $branch);
+    }
+
+    public function downloadRepoZipToTempFile(string $repository, string $branch = 'main'): string|bool
+    {
+        $url = $this->getRepoZipUrl($repository, $branch);
+
+        $response = $this->api(
+            $url,
+            [
+                'headers' => $this->getHeaders()
+            ],
+            [
+                'jsonDecodeBody' => false
+            ]
         );
-
-        $getArgs = [
-            'headers' => $this->getHeaders()
-        ];
-
-        $args = [
-            'jsonDecodeBody' => false
-        ];
-
-        $response = $this->api($url, $getArgs, $args);
 
         if (!$response || $this->isRateLimitReached()) {
             return false;
         }
 
-        $cdHeader = $response['headers']['content-disposition'] ?? '';
-        if (empty($cdHeader)) {
+        if (!function_exists('wp_tempnam')) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        $dest = wp_tempnam($repository . '.zip');
+        if (!$dest) {
+            $this->error = __('Could not create temporary file.', 'rrze-updater');
             return false;
         }
 
-        preg_match('/filename="?([^"]+)"?/', $cdHeader, $m);
-        $filename = $m[1] ?? '';
-        if (empty($filename)) {
+        if (false === file_put_contents($dest, $response['body'])) {
+            @unlink($dest);
+            $this->error = __('Could not write ZIP archive to temporary file.', 'rrze-updater');
             return false;
         }
-
-        $uploadDir = wp_upload_dir();
-        $dest = trailingslashit($uploadDir['path']) . $filename;
-
-        file_put_contents($dest, $response['body']);
 
         return $dest;
+    }
+
+    private function getRepoZipUrl(string $repository, string $branch = 'main'): string
+    {
+        return sprintf(
+            'https://api.github.com/repos/%1$s/%2$s/zipball/%3$s',
+            $this->owner,
+            $repository,
+            $branch
+        );
     }
 
     /**

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -11,6 +11,7 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 use RRZE\Updater\Settings;
 use RRZE\Updater\Controller;
 
+use RRZE\Updater\Core\GithubConnector;
 use RRZE\Updater\Core\GitlabConnector;
 use RRZE\Updater\Core\Plugin;
 
@@ -55,21 +56,10 @@ class Main
      */
     public $currentExtension;
 
-    /**
-     * Main constructor.
-     *
-     * Initializes the RRZE Updater plugin by creating instances of the necessary components.
-     * It sets up the plugin for use within WordPress.
-     */
     public function __construct()
     {
-        // Add a new Settings instance for managing plugin settings.
         $this->settings = new Settings();
-
-        // Add a new Controller instance and pass in the settings.
         $this->controller = new Controller($this->settings);
-
-        // Initialize the Cron component for scheduling and running periodic tasks.
         new Cron($this->settings, $this->controller);
     }
 
@@ -82,16 +72,12 @@ class Main
      */
     public function loaded()
     {
-        // Initialize plugin settings.
         $this->initSettings();
 
-        // Set up hooks and actions based on whether it's a multisite or single site.
         if (!is_multisite()) {
-            // Single site setup.
             add_action('admin_menu', [$this, 'adminMenu']);
             add_filter('plugin_action_links', [$this, 'pluginActionLinks'], 10, 2);
         } else {
-            // Multisite network admin setup.
             add_action('network_admin_menu', [$this, 'adminMenu']);
             add_filter('network_admin_plugin_action_links', [$this, 'pluginActionLinks'], 10, 2);
         }
@@ -101,6 +87,9 @@ class Main
         add_filter('site_transient_update_themes', [$this, 'siteTransientUpdateThemes']);
         add_filter('pre_set_site_transient_update_plugins', [$this, 'preSetSiteTransientUpdatePlugins']);
         add_filter('pre_set_site_transient_update_themes', [$this, 'preSetSiteTransientUpdateThemes']);
+
+        // Download authenticated GitHub packages only when the upgrader actually needs them.
+        add_filter('upgrader_pre_download', [$this, 'upgraderPreDownloadFilter'], 10, 4);
 
         // Set up a filter for modifying the source selection during plugin/theme updates.
         add_filter('upgrader_source_selection', [$this, 'upgraderSourceSelectionFilter'], 10, 4);
@@ -127,40 +116,40 @@ class Main
     {
         // Add the main "Repositories" menu page.
         $repoPage = add_menu_page(
-            __('Repositories', 'rrze-updater'),  // Page title
-            __('Repositories', 'rrze-updater'),  // Menu title
-            'manage_options',                    // Capability required to access
-            'rrze-updater',                      // Menu slug
-            [$this->controller, 'getRepoIndex'], // Callback function for the page content
-            'dashicons-update'                   // Dashicon icon
+            __('Repositories', 'rrze-updater'),             // Page title
+            __('Repositories', 'rrze-updater'),             // Menu title
+            'manage_options',                      // Capability required to access
+            'rrze-updater',                       // Menu slug
+            [$this->controller, 'getRepoIndex'],            // Callback function for the page content
+            'dashicons-update'                      // Dashicon icon
         );
 
         // Add submenu pages for "Services," "Plugins," and "Themes."
         $connPage = add_submenu_page(
-            'rrze-updater',                          // Parent menu slug
-            __('Services', 'rrze-updater'),          // Page title
-            __('Services', 'rrze-updater'),          // Menu title
-            'manage_options',                        // Capability required to access
-            'rrze-updater-connectors',               // Menu slug
-            [$this->controller, 'getConnectorIndex'] // Callback function for the page content
+            'rrze-updater',                      // Parent menu slug
+            __('Services', 'rrze-updater'),                 // Page title
+            __('Services', 'rrze-updater'),                 // Menu title
+            'manage_options',                      // Capability required to access
+            'rrze-updater-connectors',            // Menu slug
+            [$this->controller, 'getConnectorIndex']        // Callback function for the page content
         );
 
         $pluginsPage = add_submenu_page(
-            'rrze-updater',                       // Parent menu slug
-            __('Plugins', 'rrze-updater'),        // Page title
-            __('Plugins', 'rrze-updater'),        // Menu title
-            'manage_options',                     // Capability required to access
+            'rrze-updater',                      // Parent menu slug
+            __('Plugins', 'rrze-updater'),                  // Page title
+            __('Plugins', 'rrze-updater'),                  // Menu title
+            'manage_options',                      // Capability required to access
             'rrze-updater-plugins',                // Menu slug
-            [$this->controller, 'getPluginIndex'] // Callback function for the page content
+            [$this->controller, 'getPluginIndex']           // Callback function for the page content
         );
 
         $themesPage = add_submenu_page(
             'rrze-updater',                      // Parent menu slug
-            __('Themes', 'rrze-updater'),        // Page title
-            __('Themes', 'rrze-updater'),        // Menu title
-            'manage_options',                    // Capability required to access
+            __('Themes', 'rrze-updater'),                   // Page title
+            __('Themes', 'rrze-updater'),                   // Menu title
+            'manage_options',                     // Capability required to access
             'rrze-updater-themes',                // Menu slug
-            [$this->controller, 'getThemeIndex'] // Callback function for the page content
+            [$this->controller, 'getThemeIndex']            // Callback function for the page content
         );
 
         // Set up screen options for each admin page.
@@ -797,6 +786,80 @@ class Main
         }
 
         return $source;
+    }
+
+    public function upgraderPreDownloadFilter($reply, $package, $upgrader, $hookExtra)
+    {
+        if (false !== $reply || !is_string($package)) {
+            return $reply;
+        }
+
+        $extension = $this->getGithubExtensionForUpgrade($upgrader, $hookExtra);
+        if (!$extension) {
+            return false;
+        }
+
+        $refs = array_filter(array_unique([
+            $extension->remoteVersion ?? '',
+            $extension->branch ?? '',
+            'main'
+        ]));
+
+        foreach ($refs as $ref) {
+            if ($package !== $extension->connector->downloadRepoZip($extension->repository, $ref)) {
+                continue;
+            }
+
+            $download = $extension->connector->downloadRepoZipToTempFile($extension->repository, $ref);
+            if (!$download) {
+                return new WP_Error(
+                    'download_failed',
+                    $extension->connector->error ?: __('Download failed.', 'rrze-updater')
+                );
+            }
+
+            return $download;
+        }
+
+        return false;
+    }
+
+    private function getGithubExtensionForUpgrade($upgrader, array $hookExtra)
+    {
+        if (
+            ($upgrader->skin instanceof PluginUpgraderSkin
+                || $upgrader->skin instanceof ThemeUpgraderSkin)
+            && $upgrader->skin->extension->connector instanceof GithubConnector
+        ) {
+            return $upgrader->skin->extension;
+        }
+
+        if (($hookExtra['type'] ?? '') == 'plugin' && !empty($hookExtra['plugin'])) {
+            $pluginFileParts = explode('/', $hookExtra['plugin']);
+            $installationFolder = $pluginFileParts[0];
+
+            foreach ($this->settings->plugins as $extension) {
+                if (
+                    $extension->installationFolder == $installationFolder
+                    && $extension->connector instanceof GithubConnector
+                ) {
+                    return $extension;
+                }
+            }
+        }
+
+        if (($hookExtra['type'] ?? '') == 'theme' && !empty($hookExtra['theme'])) {
+            foreach ($this->settings->themes as $extension) {
+                if (
+                    $extension->installationFolder == $hookExtra['theme']
+                    && $extension->connector instanceof GithubConnector
+                ) {
+                    return $extension;
+                }
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/rrze-updater.php
+++ b/rrze-updater.php
@@ -24,53 +24,32 @@ defined('ABSPATH') || exit;
  * Register a custom autoloader (PSR-4) using spl_autoload_register().
  */
 spl_autoload_register(function ($class) {
-    // Define the namespace prefix for the classes.
     $prefix = __NAMESPACE__;
-
-    // Define the base directory where the class files are located.
     $baseDir = __DIR__ . '/includes/';
+    $lengthOfNamespacePrefix = strlen($prefix);
 
-    // Calculate the length of the namespace prefix.
-    $len = strlen($prefix);
-
-    // Check if the provided class starts with the defined namespace prefix.
-    if (strncmp($prefix, $class, $len) !== 0) {
-        return; // The class does not belong to this namespace, so no action is taken.
+    if (strncmp($prefix, $class, $lengthOfNamespacePrefix) !== 0) {
+        return;
     }
 
-    // Extract the relative class name (without the namespace).
-    $relativeClass = substr($class, $len);
-
-    // Build the file path based on the namespace and relative class name.
+    $relativeClass = substr($class, $lengthOfNamespacePrefix);
     $file = $baseDir . str_replace('\\', '/', $relativeClass) . '.php';
 
-    // Check if the file exists before attempting to include it.
     if (file_exists($file)) {
-        require $file; // Include the class file.
+        require $file;
     }
 });
 
-// Load the plugin's text domain for localization.
+
 add_action('init', fn() => load_plugin_textdomain('rrze-updater', false, dirname(plugin_basename(__FILE__)) . '/languages'));
+add_action('plugins_loaded', __NAMESPACE__ . '\loaded');
 
-// Register activation hook for the plugin
 register_activation_hook(__FILE__, __NAMESPACE__ . '\activation');
-
-// Register deactivation hook for the plugin
 register_deactivation_hook(__FILE__, __NAMESPACE__ . '\deactivation');
 
-/**
- * Add an action hook for the 'plugins_loaded' hook.
- *
- * This code hooks into the 'plugins_loaded' action hook to execute a callback function when
- * WordPress has fully loaded all active plugins and the theme's functions.php file.
- */
-add_action('plugins_loaded', __NAMESPACE__ . '\loaded');
 
 /**
  * Handle the activation of the plugin.
- *
- * This function is called when the plugin is activated.
  */
 function activation($networkWide)
 {
@@ -79,13 +58,9 @@ function activation($networkWide)
 
 /**
  * Handle the deactivation of the plugin.
- *
- * This function is called when the plugin is deactivated.
- * It clears any scheduled cron jobs associated with the plugin.
  */
 function deactivation()
 {
-    // Clear any scheduled cron jobs associated with the plugin.
     Cron::clearSchedule();
 }
 
@@ -98,16 +73,13 @@ function deactivation()
  */
 function plugin()
 {
-    // Declare a static variable to hold the instance.
     static $instance;
 
     // Check if the instance is not already created.
     if (null === $instance) {
-        // Add a new instance of the Plugin class, passing the current file (__FILE__) as a parameter.
         $instance = new Plugin(__FILE__);
     }
 
-    // Return the main instance of the Plugin class.
     return $instance;
 }
 
@@ -121,16 +93,10 @@ function plugin()
  */
 function systemRequirements(): string
 {
-    // Get the global WordPress version.
     global $wp_version;
-
-    // Get the PHP version.
     $phpVersion = phpversion();
-
-    // Initialize an error message string.
     $error = '';
 
-    // Check if the WordPress version is compatible with the plugin's requirement.
     if (!is_wp_version_compatible(plugin()->getRequiresWP())) {
         $error = sprintf(
             /* translators: 1: Server WordPress version number, 2: Required WordPress version number. */
@@ -139,7 +105,6 @@ function systemRequirements(): string
             plugin()->getRequiresWP()
         );
     } elseif (!is_php_version_compatible(plugin()->getRequiresPHP())) {
-        // Check if the PHP version is compatible with the plugin's requirement.
         $error = sprintf(
             /* translators: 1: Server PHP version number, 2: Required PHP version number. */
             __('The server is running PHP version %1$s. The plugin requires at least PHP version %2$s.', 'rrze-updater'),
@@ -147,11 +112,8 @@ function systemRequirements(): string
             plugin()->getRequiresPHP()
         );
     } elseif (is_multisite() && !is_plugin_active_for_network(plugin()->getBaseName())) {
-        // Set an error message indicating that the plugin can only be installed network-wide in a multisite installation.
         $error = __('In a multisite installation, the plugin can only be installed network-wide.', 'rrze-updater');
     }
-
-    // Return the error message string, which will be empty if requirements are satisfied.
     return $error;
 }
 
@@ -163,23 +125,16 @@ function systemRequirements(): string
  */
 function loaded()
 {
-    // Trigger the 'loaded' method of the main plugin instance.
     plugin()->loaded();
 
-    // Check system requirements.
     if (systemRequirements()) {
-        // If there is an error, add an action to display an admin notice with the error message.
         add_action('admin_init', function () {
             $error = systemRequirements();
-            // Check if the current user has the capability to activate plugins.
             if (current_user_can('activate_plugins')) {
-                // Get plugin data to retrieve the plugin's name.
                 $pluginName = plugin()->getName();
 
-                // Determine the admin notice tag based on network-wide activation.
                 $tag = is_plugin_active_for_network(plugin()->getBaseName()) ? 'network_admin_notices' : 'admin_notices';
 
-                // Add an action to display the admin notice.
                 add_action($tag, function () use ($pluginName, $error) {
                     printf(
                         '<div class="notice notice-error"><p>' .
@@ -193,10 +148,8 @@ function loaded()
             }
         });
 
-        // Return to prevent further initialization if there is an error.
         return;
     }
 
-    // If there are no errors, create an instance of the 'Main' class and trigger its 'loaded' method.
     (new Main)->loaded();
 }


### PR DESCRIPTION
…during updates

Integrates with the `upgrader_pre_download` hook to allow the custom `GithubConnector` to handle package downloads for GitHub-managed plugins and themes.

This is crucial for updating private repositories or those requiring specific authentication, as the default WordPress upgrader cannot leverage the connector's authentication mechanisms. The `GithubConnector` has been refactored to support downloading directly to temporary files, a requirement for this integration.

Also includes significant cleanup of verbose comments across several core plugin files.